### PR TITLE
Backport 3.0.1 functionality to v2.3.2

### DIFF
--- a/actions/describeTimeToLive.js
+++ b/actions/describeTimeToLive.js
@@ -1,0 +1,8 @@
+
+module.exports = function describeTimeToLive(store, data, cb) {
+  store.getTable(data.TableName, false, function(err, table) {
+    if (err) return cb(err)
+
+    cb(null, {})
+  })
+}

--- a/actions/listTagsOfResource.js
+++ b/actions/listTagsOfResource.js
@@ -1,0 +1,4 @@
+
+module.exports = function tag(store, data, cb) {
+    cb(null, {Tags: []})
+}

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ var MAX_REQUEST_BYTES = 16 * 1024 * 1024
 
 var validApis = ['DynamoDB_20111205', 'DynamoDB_20120810'],
     validOperations = ['BatchGetItem', 'BatchWriteItem', 'CreateTable', 'DeleteItem', 'DeleteTable',
-      'DescribeTable', 'GetItem', 'ListTables', 'PutItem', 'Query', 'Scan', 'TagResource', 'UntagResource',
-      'UpdateItem', 'UpdateTable'],
+      'DescribeTable', 'DescribeTimeToLive', 'GetItem', 'ListTables', 'PutItem', 'Query', 'Scan', 'TagResource',
+      'UntagResource', 'ListTagsOfResource', 'UpdateItem', 'UpdateTable'],
     actions = {},
     actionValidations = {}
 

--- a/validations/describeTimeToLive.js
+++ b/validations/describeTimeToLive.js
@@ -1,0 +1,8 @@
+exports.types = {
+  TableName: {
+    type: 'String',
+    required: true,
+    tableName: true,
+    regex: '[a-zA-Z0-9_.-]+',
+  },
+}

--- a/validations/listTagsOfResource.js
+++ b/validations/listTagsOfResource.js
@@ -3,6 +3,6 @@ exports.types = {
     type: 'String',
     required: true,
     tableName: false,
-    regex: 'arn:(aws[a-zA-Z-]*)?:dynamodb:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:table:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?',
+    regex: 'arn:aws:dynamodb:(.+):(.+):table/(.+)',
   },
 }

--- a/validations/listTagsOfResource.js
+++ b/validations/listTagsOfResource.js
@@ -1,0 +1,8 @@
+exports.types = {
+  ResourceArns: {
+    type: 'String',
+    required: true,
+    tableName: false,
+    regex: 'arn:(aws[a-zA-Z-]*)?:dynamodb:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\\d{1}:\\d{12}:table:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?',
+  },
+}


### PR DESCRIPTION
Backport [`3.0.1`](https://github.com/lyft/dynalite/releases/tag/3.0.1) changes to `V2.3.2`.  This is required for dynalite to work with Terraform.  We cannot use `3.0.1` since it causes upstream tests to fail https://github.com/lyft/containers/pull/11599 (the `3.0.0` release upgraded many of the dependencies and debugging them is not worth it).

* Merge pull request #1 from lyft/mock-missing-functions: d03cb99101607cce761adb5dc2a6369a2a1f5db3
* modify the table arn regex: 54f0b4c896314ad977f97ee3fa6373ed42646818
* mock describeTimeToLive + listTagsOfResource: d32a537ff68401296c4db79415ac51deb025c31a