### PR TITLE
Merge pull request from mhart/dynalite to support empty string and binary values

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -164,6 +164,10 @@ function validateItem(dataItem, table) {
         'Type mismatch for key ' + attr + ' expected: ' + type +
         ' actual: ' + Object.keys(dataItem[attr])[0])
     }
+    if (dataItem[attr][type] === '' && (type === 'S' || type === 'B')) {
+      return validationError('One or more parameter values are not valid. ' +
+        'The AttributeValue for a key attribute cannot contain an empty ' + (type === 'S' ? 'string' : 'binary') + ' value. Key: ' + attr)
+    }
     return checkKeySize(dataItem[attr][type], type, isHash)
   }) || traverseIndexes(table, function(attr, type, index) {
     if (dataItem[attr] != null && dataItem[attr][type] == null) {
@@ -220,6 +224,10 @@ function validateUpdates(attributeUpdates, expressionUpdates, table) {
 function validateKeyPiece(key, attr, type, isHash) {
   if (key[attr] == null || key[attr][type] == null) {
     return validationError('The provided key element does not match the schema')
+  }
+  if (key[attr][type] === '' && (type === 'S' || type === 'B')) {
+    return validationError('One or more parameter values were invalid: ' +
+      'The AttributeValue for a key attribute cannot contain an empty ' + (type === 'S' ? 'string' : 'binary') + ' value. Key: ' + attr)
   }
   return checkKeySize(key[attr][type], type, isHash)
 }

--- a/test/batchWriteItem.js
+++ b/test/batchWriteItem.js
@@ -214,14 +214,10 @@ describe('batchWriteItem', function() {
 
     it('should return ValidationException for invalid values in Item', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -232,6 +228,7 @@ describe('batchWriteItem', function() {
 
     it('should return ValidationException for empty/invalid numbers in Item', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],

--- a/test/createTable.js
+++ b/test/createTable.js
@@ -401,25 +401,25 @@ describe('createTable', function() {
         KeySchema: [{KeyType: 'HASH', AttributeName: 'a'}, {KeyType: 'RANGE', AttributeName: 'b'}],
         LocalSecondaryIndexes: [{}, {}, {}, {}, {}, {}, {}, {}, {}],
         ProvisionedThroughput: {ReadCapacityUnits: 1, WriteCapacityUnits: 1}}, [
+          'Value null at \'localSecondaryIndexes.1.member.indexName\' failed to satisfy constraint: ' +
+          'Member must not be null',
           'Value null at \'localSecondaryIndexes.1.member.keySchema\' failed to satisfy constraint: ' +
           'Member must not be null',
           'Value null at \'localSecondaryIndexes.1.member.projection\' failed to satisfy constraint: ' +
           'Member must not be null',
-          'Value null at \'localSecondaryIndexes.1.member.indexName\' failed to satisfy constraint: ' +
+          'Value null at \'localSecondaryIndexes.2.member.indexName\' failed to satisfy constraint: ' +
           'Member must not be null',
           'Value null at \'localSecondaryIndexes.2.member.keySchema\' failed to satisfy constraint: ' +
           'Member must not be null',
           'Value null at \'localSecondaryIndexes.2.member.projection\' failed to satisfy constraint: ' +
           'Member must not be null',
-          'Value null at \'localSecondaryIndexes.2.member.indexName\' failed to satisfy constraint: ' +
+          'Value null at \'localSecondaryIndexes.3.member.indexName\' failed to satisfy constraint: ' +
           'Member must not be null',
           'Value null at \'localSecondaryIndexes.3.member.keySchema\' failed to satisfy constraint: ' +
           'Member must not be null',
           'Value null at \'localSecondaryIndexes.3.member.projection\' failed to satisfy constraint: ' +
           'Member must not be null',
-          'Value null at \'localSecondaryIndexes.3.member.indexName\' failed to satisfy constraint: ' +
-          'Member must not be null',
-          'Value null at \'localSecondaryIndexes.4.member.keySchema\' failed to satisfy constraint: ' +
+          'Value null at \'localSecondaryIndexes.4.member.indexName\' failed to satisfy constraint: ' +
           'Member must not be null',
         ], done)
     })
@@ -736,7 +736,7 @@ describe('createTable', function() {
           'Member must not be null',
           'Value null at \'globalSecondaryIndexes.3.member.indexName\' failed to satisfy constraint: ' +
           'Member must not be null',
-          'Value null at \'globalSecondaryIndexes.4.member.keySchema\' failed to satisfy constraint: ' +
+          'Value null at \'globalSecondaryIndexes.4.member.indexName\' failed to satisfy constraint: ' +
           'Member must not be null',
         ], done)
     })

--- a/test/deleteItem.js
+++ b/test/deleteItem.js
@@ -225,14 +225,10 @@ describe('deleteItem', function() {
 
     it('should return ValidationException for invalid values in ExpressionAttributeValues', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -248,6 +244,7 @@ describe('deleteItem', function() {
 
     it('should return ValidationException for empty/invalid numbers in ExpressionAttributeValues', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],
@@ -310,14 +307,10 @@ describe('deleteItem', function() {
 
     it('should return ValidationException for invalid values in Key', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -328,6 +321,7 @@ describe('deleteItem', function() {
 
     it('should return ValidationException for empty/invalid numbers in Key', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],

--- a/test/getItem.js
+++ b/test/getItem.js
@@ -143,14 +143,10 @@ describe('getItem', function() {
 
     it('should return ValidationException for invalid values in Key', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -161,6 +157,7 @@ describe('getItem', function() {
 
     it('should return ValidationException for empty/invalid numbers in Key', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],
@@ -335,6 +332,18 @@ describe('getItem', function() {
     it('should return ValidationException if range key does not match schema', function(done) {
       assertValidation({TableName: helpers.testRangeTable, Key: {a: {S: 'a'}}},
         'The provided key element does not match the schema', done)
+    })
+
+    it('should return ValidationException if string key has empty string', function(done) {
+      assertValidation({TableName: helpers.testHashTable, Key: {a: {S: ''}}},
+        'One or more parameter values were invalid: ' +
+        'The AttributeValue for a key attribute cannot contain an empty string value. Key: a', done)
+    })
+
+    it('should return ValidationException if binary key has empty string', function(done) {
+      assertValidation({TableName: helpers.testRangeBTable, Key: {a: {S: 'a'}, b: {B: ''}}},
+        'One or more parameter values were invalid: ' +
+        'The AttributeValue for a key attribute cannot contain an empty binary value. Key: b', done)
     })
 
     it('should return ValidationException if hash key is too big', function(done) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -357,6 +357,7 @@ function assertType(target, property, type, done) {
     type = subtypeMatch[1]
     subtype = subtypeMatch[2]
   }
+  var castMsg = "class sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to class java.lang.Class (sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl and java.lang.Class are in module java.base of loader 'bootstrap')"
   switch (type) {
     case 'Boolean':
       msgs = [
@@ -426,12 +427,12 @@ function assertType(target, property, type, done) {
       break
     case 'ParameterizedList':
       msgs = [
-        ['23', 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [true, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [23, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [-2147483648, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [2147483648, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [34.56, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
+        ['23', castMsg],
+        [true, castMsg],
+        [23, castMsg],
+        [-2147483648, castMsg],
+        [2147483648, castMsg],
+        [34.56, castMsg],
         [{}, 'Start of structure or map found where not expected'],
       ]
       break
@@ -448,12 +449,12 @@ function assertType(target, property, type, done) {
       break
     case 'ParameterizedMap':
       msgs = [
-        ['23', 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [true, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [23, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [-2147483648, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [2147483648, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
-        [34.56, 'sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class'],
+        ['23', castMsg],
+        [true, castMsg],
+        [23, castMsg],
+        [-2147483648, castMsg],
+        [2147483648, castMsg],
+        [34.56, castMsg],
         [[], 'Unrecognized collection type java.util.Map<java.lang.String, com.amazonaws.dynamodb.v20120810.AttributeValue>'],
       ]
       break
@@ -521,7 +522,6 @@ function assertType(target, property, type, done) {
 function assertValidation(target, data, msg, done) {
   request(opts(target, data), function(err, res) {
     if (err) return done(err)
-    res.statusCode.should.equal(400)
     if (typeof res.body !== 'object') {
       return done(new Error('Not JSON: ' + res.body))
     }
@@ -538,6 +538,7 @@ function assertValidation(target, data, msg, done) {
     } else {
       res.body.message.should.equal(msg)
     }
+    res.statusCode.should.equal(400)
     done()
   })
 }

--- a/test/query.js
+++ b/test/query.js
@@ -317,14 +317,10 @@ describe('query', function() {
 
     it('should return ValidationException for invalid values in QueryFilter', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -340,6 +336,7 @@ describe('query', function() {
 
     it('should return ValidationException for empty/invalid numbers in QueryFilter', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],
@@ -450,16 +447,9 @@ describe('query', function() {
         {KeyConditionExpression: '', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}},
       ], function(keyOpts, cb) {
         async.forEach([
-          [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-          [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
           [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
           [{SS: []}, 'An string set  may not be empty'],
-          [{NS: []}, 'An number set  may not be empty'],
           [{BS: []}, 'Binary sets should not be empty'],
-          [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-          [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
-          [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
-          [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
         ], function(expr, cb) {
           assertValidation({
             TableName: 'abc',
@@ -472,12 +462,33 @@ describe('query', function() {
       }, done)
     })
 
+    it('should return ValidationException for invalid values in ExclusiveStartKey without provided message', function(done) {
+      async.forEach([
+        {KeyConditions: {a: {ComparisonOperator: 'EQ', AttributeValueList: [{}, {}]}}},
+        {KeyConditionExpression: '', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}},
+      ], function(keyOpts, cb) {
+        async.forEach([
+          [{NS: []}, 'An number set  may not be empty'],
+          [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
+          [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
+        ], function(expr, cb) {
+          assertValidation({
+            TableName: 'abc',
+            KeyConditions: keyOpts.KeyConditions,
+            KeyConditionExpression: keyOpts.KeyConditionExpression,
+            ExclusiveStartKey: {a: expr[0]},
+          }, 'One or more parameter values were invalid: ' + expr[1], cb)
+        }, cb)
+      }, done)
+    })
+
     it('should return ValidationException for empty/invalid numbers in ExclusiveStartKey', function(done) {
       async.forEach([
         {KeyConditions: {a: {ComparisonOperator: 'EQ', AttributeValueList: [{}]}}},
         {KeyConditionExpression: '', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}},
       ], function(keyOpts, cb) {
         async.forEach([
+          [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
           [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
           [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
           [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],
@@ -495,7 +506,7 @@ describe('query', function() {
             KeyConditions: keyOpts.KeyConditions,
             KeyConditionExpression: keyOpts.KeyConditionExpression,
             ExclusiveStartKey: {a: expr[0]},
-          }, 'The provided starting key is invalid: ' + expr[1], cb)
+          }, expr[1], cb)
         }, cb)
       }, done)
     })
@@ -530,14 +541,10 @@ describe('query', function() {
 
     it('should return ValidationException for invalid values in KeyConditions', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -550,6 +557,7 @@ describe('query', function() {
 
     it('should return ValidationException for empty/invalid numbers in KeyConditions', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],

--- a/test/updateItem.js
+++ b/test/updateItem.js
@@ -213,14 +213,10 @@ describe('updateItem', function() {
 
     it('should return ValidationException for invalid values in Key', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {
@@ -235,6 +231,7 @@ describe('updateItem', function() {
 
     it('should return ValidationException for empty/invalid numbers in Key', function(done) {
       async.forEach([
+        [{S: '', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: ''}, 'The parameter cannot be converted to a numeric value'],
         [{S: 'a', N: 'b'}, 'The parameter cannot be converted to a numeric value: b'],
         [{NS: ['1', '']}, 'The parameter cannot be converted to a numeric value'],
@@ -389,14 +386,10 @@ describe('updateItem', function() {
 
     it('should return ValidationException for invalid values in ExpressionAttributeValues', function(done) {
       async.forEach([
-        [{N: '', S: ''}, 'An AttributeValue may not contain an empty string'],
-        [{B: ''}, 'An AttributeValue may not contain a null or empty binary type.'],
         [{NULL: 'no'}, 'Null attribute value types must have the value of true'],
         [{SS: []}, 'An string set  may not be empty'],
         [{NS: []}, 'An number set  may not be empty'],
         [{BS: []}, 'Binary sets should not be empty'],
-        [{SS: ['a', '']}, 'An string set may not have a empty string as a member'],
-        [{BS: ['aaaa', '']}, 'Binary sets may not contain null or empty values'],
         [{SS: ['a', 'a']}, 'Input collection [a, a] contains duplicates.'],
         [{BS: ['Yg==', 'Yg==']}, 'Input collection [Yg==, Yg==]of type BS contains duplicates.'],
       ], function(expr, cb) {

--- a/validations/batchGetItem.js
+++ b/validations/batchGetItem.js
@@ -56,6 +56,14 @@ exports.custom = function(data) {
     var msg = validations.validateExpressionParams(tableData, ['ProjectionExpression'], ['AttributesToGet'])
     if (msg) return msg
 
+    if (tableData.AttributesToGet) {
+      msg = validations.findDuplicate(tableData.AttributesToGet)
+      if (msg) return 'One or more parameter values were invalid: Duplicate value in attribute name: ' + msg
+    }
+
+    msg = validations.validateExpressions(tableData)
+    if (msg) return msg
+
     var seenKeys = Object.create(null)
     for (var i = 0; i < tableData.Keys.length; i++) {
       var key = tableData.Keys[i]
@@ -75,13 +83,5 @@ exports.custom = function(data) {
       if (numReqs > 100)
         return 'Too many items requested for the BatchGetItem call'
     }
-
-    if (tableData.AttributesToGet) {
-      msg = validations.findDuplicate(tableData.AttributesToGet)
-      if (msg) return 'One or more parameter values were invalid: Duplicate value in attribute name: ' + msg
-    }
-
-    msg = validations.validateExpressions(tableData)
-    if (msg) return msg
   }
 }

--- a/validations/createTable.js
+++ b/validations/createTable.js
@@ -63,6 +63,13 @@ exports.types = {
     children: {
       type: 'ValueStruct<LocalSecondaryIndex>',
       children: {
+        IndexName: {
+          type: 'String',
+          notNull: true,
+          regex: '[a-zA-Z0-9_.-]+',
+          lengthGreaterThanOrEqual: 3,
+          lengthLessThanOrEqual: 255,
+        },
         KeySchema: {
           type: 'List',
           notNull: true,
@@ -96,13 +103,6 @@ exports.types = {
               children: 'String',
             },
           },
-        },
-        IndexName: {
-          type: 'String',
-          notNull: true,
-          regex: '[a-zA-Z0-9_.-]+',
-          lengthGreaterThanOrEqual: 3,
-          lengthLessThanOrEqual: 255,
         },
       },
     },
@@ -112,6 +112,13 @@ exports.types = {
     children: {
       type: 'ValueStruct<GlobalSecondaryIndex>',
       children: {
+        IndexName: {
+          type: 'String',
+          notNull: true,
+          regex: '[a-zA-Z0-9_.-]+',
+          lengthGreaterThanOrEqual: 3,
+          lengthLessThanOrEqual: 255,
+        },
         KeySchema: {
           type: 'List',
           notNull: true,
@@ -145,13 +152,6 @@ exports.types = {
               children: 'String',
             },
           },
-        },
-        IndexName: {
-          type: 'String',
-          notNull: true,
-          regex: '[a-zA-Z0-9_.-]+',
-          lengthGreaterThanOrEqual: 3,
-          lengthLessThanOrEqual: 255,
         },
         ProvisionedThroughput: {
           type: 'FieldStruct<ProvisionedThroughput>',

--- a/validations/index.js
+++ b/validations/index.js
@@ -162,7 +162,7 @@ function checkTypes(data, types) {
           case 'boolean':
           case 'number':
           case 'string':
-            throw typeError('sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class')
+            throw typeError("class sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to class java.lang.Class (sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl and java.lang.Class are in module java.base of loader 'bootstrap')")
           case 'object':
             if (!Array.isArray(val)) throw typeError('Start of structure or map found where not expected')
         }
@@ -172,7 +172,7 @@ function checkTypes(data, types) {
           case 'boolean':
           case 'number':
           case 'string':
-            throw typeError('sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to java.lang.Class')
+            throw typeError("class sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl cannot be cast to class java.lang.Class (sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl and java.lang.Class are in module java.base of loader 'bootstrap')")
           case 'object':
             if (Array.isArray(val)) throw typeError('Unrecognized collection type java.util.Map<java.lang.String, com.amazonaws.dynamodb.v20120810.AttributeValue>')
         }
@@ -370,12 +370,6 @@ function validateAttributeValue(value) {
       if (msg) return msg
     }
 
-    if (type == 'B' && !value[type])
-      return 'One or more parameter values were invalid: An AttributeValue may not contain a null or empty binary type.'
-
-    if (type == 'S' && !value[type])
-      return 'One or more parameter values were invalid: An AttributeValue may not contain an empty string'
-
     if (type == 'NULL' && !value[type])
       return 'One or more parameter values were invalid: Null attribute value types must have the value of true'
 
@@ -387,12 +381,6 @@ function validateAttributeValue(value) {
 
     if (type == 'BS' && !value[type].length)
       return 'One or more parameter values were invalid: Binary sets should not be empty'
-
-    if (type == 'SS' && value[type].some(function(x) { return !x })) // eslint-disable-line no-loop-func
-      return 'One or more parameter values were invalid: An string set may not have a empty string as a member'
-
-    if (type == 'BS' && value[type].some(function(x) { return !x })) // eslint-disable-line no-loop-func
-      return 'One or more parameter values were invalid: Binary sets may not contain null or empty values'
 
     if (type == 'NS') {
       for (i = 0; i < value[type].length; i++) {

--- a/validations/query.js
+++ b/validations/query.js
@@ -113,7 +113,9 @@ exports.custom = function(data) {
 
   for (key in data.ExclusiveStartKey) {
     msg = validations.validateAttributeValue(data.ExclusiveStartKey[key])
-    if (msg) return 'The provided starting key is invalid: ' + msg
+    // For some reason this message is only added to some messages...?
+    var prepend = /contains duplicates|number set|numeric value|significant digits|number with magnitude/.test(msg) ? '' : 'The provided starting key is invalid: '
+    if (msg) return prepend + msg
   }
 
   if (data.KeyConditions == null && data.KeyConditionExpression == null) {

--- a/validations/scan.js
+++ b/validations/scan.js
@@ -51,15 +51,15 @@ exports.types = {
     type: 'Integer',
     greaterThanOrEqual: 0,
   },
+  Limit: {
+    type: 'Integer',
+    greaterThanOrEqual: 1,
+  },
   AttributesToGet: {
     type: 'List',
     lengthGreaterThanOrEqual: 1,
     lengthLessThanOrEqual: 255,
     children: 'String',
-  },
-  Limit: {
-    type: 'Integer',
-    greaterThanOrEqual: 1,
   },
   ExclusiveStartKey: {
     type: 'Map<AttributeValue>',
@@ -98,7 +98,9 @@ exports.custom = function(data) {
 
   for (var key in data.ExclusiveStartKey) {
     msg = validations.validateAttributeValue(data.ExclusiveStartKey[key])
-    if (msg) return 'The provided starting key is invalid: ' + msg
+    // For some reason this message is only added to some messages...?
+    var prepend = /contains duplicates|number set|numeric value|significant digits|number with magnitude/.test(msg) ? '' : 'The provided starting key is invalid: '
+    if (msg) return prepend + msg
   }
 
   if (data.Segment && data.TotalSegments == null) {


### PR DESCRIPTION
Includes the following commits to support [empty value](https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-dynamodb-now-supports-empty-values-for-non-key-string-and-binary-attributes-in-dynamodb-tables/):
* Merge pull request from mhart/dynalite: [8a4a8d1](https://github.com/mhart/dynalite/commit/8a4a8d1a568e1110da3a1f8b4ae18aeb323966db)
* Merge pull request from mhart/dynalite: [41dec26](https://github.com/mhart/dynalite/commit/41dec26f13f727a7f38ad3e61c00a25a8a5f93e6)

We need empty value support in development to match the production table behaviors.

PS: Have to flatten the merged commits to make read-to-merge. Luckily, upstream repo is using MIT license.